### PR TITLE
test(sample-multi-party): fix delay errors

### DIFF
--- a/packages/node_modules/sample-browser-single-party-call/test/wdio/specs/dial-and-reject.js
+++ b/packages/node_modules/sample-browser-single-party-call/test/wdio/specs/dial-and-reject.js
@@ -37,7 +37,7 @@ describe(`sample-browser-single-party-call`, () => {
       browserSpock.click(`[title="dial"]`);
 
       // TODO how do we wait for a modal to open?
-      browserSpock.pause(3000);
+      browserSpock.pause(8000);
       browserMccoy.alertDismiss();
     });
   });

--- a/packages/node_modules/sample-browser-single-party-call/test/wdio/specs/normal-dialing.js
+++ b/packages/node_modules/sample-browser-single-party-call/test/wdio/specs/normal-dialing.js
@@ -38,7 +38,7 @@ describe(`sample-browser-single-party-call`, () => {
       browserSpock.click(`[title="dial"]`);
 
       // TODO how do we wait for a modal to open?
-      browserSpock.pause(3000);
+      browserSpock.pause(8000);
       browserMccoy.alertAccept();
     });
 


### PR DESCRIPTION
the tests were moving faster too fast for the browser driver; adding time to the delays fixed all the errors